### PR TITLE
Sync hosts view after deleting a host

### DIFF
--- a/core/main.py
+++ b/core/main.py
@@ -436,6 +436,8 @@ class Handler():
 		
 		elif response == Gtk.ResponseType.CANCEL:
 			dialog.close()
+			
+		self._sync()
 
 	def services_row(self, listbox, cell, listboxrow):
 		""" serviceslist service click event


### PR DESCRIPTION
After deleting a host, the hosts list remain the same since `_sync` is not called.